### PR TITLE
Create scf Python package

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,32 @@
+name: Build and test [Python 3.6, 3.7, 3.8]
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda using Python ${{ matrix.python-version }}
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          activate-environment: scf
+          environment-file: environment.yml
+          python-version: ${{ matrix.python-version }}
+          auto-activate-base: false
+
+      - name: Build
+        shell: bash -l {0}
+        run: pip install -e .
+
+      - name: Test
+        shell: bash -l {0}
+        run: pytest

--- a/.github/workflows/check_jupyterbook.yml
+++ b/.github/workflows/check_jupyterbook.yml
@@ -1,0 +1,25 @@
+name: Test that Jupyter-Book builds
+on: [push, pull_request]
+jobs:
+  build:
+    if: github.repository == 'MaxGhenis/scf'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2  # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          activate-environment: scf
+          environment-file: environment.yml
+          python-version: 3.8
+          auto-activate-base: false
+
+      - name: Build  # Build Jupyter Book
+        shell: bash -l {0}
+        run: |
+          pip install -e .
+          jb build docs/.

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -1,0 +1,34 @@
+name: Build and Deploy Jupyter Book
+on:
+  push:
+    branches:    
+      - master
+jobs:
+  build-and-deploy:
+    if: github.repository == 'MaxGhenis/scf'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2  # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          environment-file: environment.yml
+          python-version: 3.8
+          auto-activate-base: false
+
+      - name: Build  # Build Jupyter Book
+        shell: bash -l {0}
+        run: |
+          pip install -e .
+          jb build docs/.
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages  # The branch the action should deploy to.
+          FOLDER: docs/_build/html  # The folder the action should deploy.

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - '**.py'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Setup Miniconda using Python ${{ matrix.python-version }}
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          activate-environment: scf
+          environment-file: environment.yml
+          python-version: ${{ matrix.python-version }}
+          auto-activate-base: false
+
+      - name: Lint
+        shell: bash -l {0}
+        run: flake8

--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -1,0 +1,51 @@
+{
+    "project_one_line": {
+        "start_header": null,
+        "end_header": null,
+        "source": null,
+        "type": "html",
+        "data": "<p>scf is a Python package for working with Survey of Consumer Finances microdata.</p>",
+    },
+    "project_overview": {
+        "start_header": null,
+        "end_header": null,
+        "source": null,
+        "type": "html",
+        "data": '<a href="https://github.com/MaxGhenis/scf">What is scf?</a>',
+    },
+    "core_maintainers": {
+        "start_header": null,
+        "end_header": null,
+        "source": null,
+        "type": "html",
+        "data": "<ul><li>Max Ghenis</li><ul><li>email: max@ubicenter.org</li></ul>",
+    },
+    "user_documentation": {
+        "start_header": null,
+        "end_header": null,
+        "source": null,
+        "type": "html",
+        "data": '<a href="http://maxghenis.github.io/scf/"></a>',
+    },
+    "contributor_overview": {
+        "start_header": null,
+        "end_header": null,
+        "source": null,
+        "type": "html",
+        "data": '<a href="http://github.com/MaxGhenis/scf/"></a>',
+    },
+    "user_changelog_recent": {
+        "start_header": null,
+        "end_header": null,
+        "source": null,
+        "type": "html",
+        "data": '<a href="https://github.com/MaxGhenis/scf/releases"></a>',
+    },
+    "link_to_webapp": {
+        "start_header": null,
+        "end_header": null,
+        "source": null,
+        "type": null,
+        "data": null,
+    },
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# `scf`
+
+`scf` is a Python package for loading and working with Survey of Consumer Finances summary microdata.
+
+For documentation on the summary microdata, see [Berkeley SDA's codebook](https://sda.berkeley.edu/sdaweb/docs/scfcomb2019/DOC/hcbk.htm).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,9 @@
+# `scf` roadmap
+
+`scf` currently provides capabilities for loading the Survey of Consumer Finances summary microdata.
+In the future, it will provide more functionality, including:
+* Functions to summarize the microdata, e.g., wealth distributions over time.
+* Charts to visualize these summaries.
+* Standard error calculations for full SCF microdata files.
+
+See the [issues page](https://github.com/MaxGhenis/scf/issues) to view and suggest other items.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,22 @@
+# Book settings
+title: scf documentation
+author: Max Ghenis
+
+launch_buttons:
+  colab_url: "https://colab.research.google.com"
+
+repository:
+  url: https://github.com/MaxGhenis/scf
+  branch: master
+  path_to_book: docs
+
+html:
+  use_edit_page_button  : true
+  use_repository_button : true
+  use_issues_button     : true
+
+sphinx:
+  extra_extensions          : ['sphinx.ext.autodoc', 'sphinx.ext.mathjax',
+                               'sphinx.ext.viewcode', 'sphinx.ext.napoleon',
+                               'alabaster']   # A list of extra extensions to load by Sphinx.
+  config                    :   # key-value pairs to directly over-ride the Sphinx configuration

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,0 +1,1 @@
+- file: home

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,0 +1,19 @@
+# `scf` documentation
+
+`scf` is a Python package for working with Survey of Consumer Finances microdata.
+
+Install via:
+
+```
+pip install git+https://github.com/MaxGhenis/scf.git
+```
+
+Try it with:
+```
+import scf
+
+scf.load(years=[2016, 2019], cols=['income', 'networth'])
+```
+
+This will return a `pandas` `DataFrame` with columns for
+`income`, `networth`, `year`, and `wgt` (the survey weight).

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
 - pytest
 - setuptools
 - pip:
-  - "--editable=git+https://github.com/PSLmodels/microdf.git"
+  - git+https://github.com/PSLmodels/microdf.git
   - jupyter-book

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: scf
+dependencies:
+- codecov
+- flake8
+- numpy
+- pandas
+- pip
+- pytest
+- setuptools
+- pip:
+  - "--editable=git+https://github.com/PSLmodels/microdf.git"
+  - jupyter-book

--- a/scf/__init__.py
+++ b/scf/__init__.py
@@ -1,0 +1,10 @@
+from .load import load
+
+
+name = "scf"
+__version__ = "0.1.0"
+
+__all__ = [
+    # load.py
+    "load",
+]

--- a/scf/load.py
+++ b/scf/load.py
@@ -1,0 +1,51 @@
+import microdf as mdf
+import pandas as pd
+
+
+def scf_url(year: int):
+    """ Returns the URL of the SCF summary microdata zip file for a year.
+
+    :param year: Year of SCF summary microdata to retrieve.
+    :type year: int
+    :return: URL of summary microdata zip file for the given year.
+    :rtype: str
+    """
+    return ('https://www.federalreserve.gov/econres/files/scfp' + 
+            str(year) + 's.zip')
+
+
+def load_single_scf(year: int, cols: list):
+    """ Loads SCF summary microdata for a given year and set of columns.
+
+    :param year: Year of SCF summary microdata to retrieve.
+    :type year: int
+    :param cols: List of columns. The weight column `wgt` is always returned.
+    :type cols: list
+    :return: SCF summary microdata for the given year.
+    :rtype: pd.DataFrame
+    """
+    # Add wgt to all returns.
+    cols = list(set(cols) | set(['wgt']))
+    return mdf.read_stata_zip(scf_url(year), columns=cols)
+
+
+def load(years: list, cols: list):
+    """ Loads SCF summary microdata for a set of years and columns.
+
+    :param years: Year(s) to load SCF data for. Can be a list or single number.
+    :type years: list
+    :param cols: List of columns. The weight column `wgt` is always returned.
+    :type cols: list
+    :return: SCF summary microdata for the set of years.
+    :rtype: pd.DataFrame
+    """
+    # If years is a single year rather than a list, return without a loop.
+    if isinstance(years, int):
+        return load_single_scf(year, cols)
+    # Otherwise append to a list within a loop, and return concatenation.
+    scfs = []
+    for year in years:
+        tmp = load_single_scf(year, cols)
+        tmp['year'] = year
+        scfs.append(tmp)
+    return pd.concat(scfs)

--- a/scf/tests/test_load.py
+++ b/scf/tests/test_load.py
@@ -1,0 +1,12 @@
+import scf
+
+
+def equal_elements(l1, l2):
+    return set(l1) == set(l2)
+
+def test_load():
+    YEARS = [2016, 2019]
+    res = scf.load(YEARS, ['income', 'networth'])
+    # Should return the specified columns, plus year and wgt.
+    assert equal_elements(res.columns, ['income', 'networth', 'wgt', 'year'])
+    assert equal_elements(res.year.unique().tolist(), YEARS)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+setup(
+    name="scf",
+    version="0.1.0",
+    description="Python package for working with the Survey of Consumer Finances microdata.",
+    url="http://github.com/maxghenis/scf",
+    author="Max Ghenis",
+    author_email="mghenis@gmail.com",
+    license="MIT",
+    packages=["scf"],
+    install_requires=[
+        "numpy",
+        "pandas",
+        "microdf",
+    ],
+    zip_safe=False,
+)


### PR DESCRIPTION
Currently it only has one function: `load(years, cols)`, which downloads and combines SCF survey microdata from the Fed website.

This PR also includes tests, GH Actions, and Jupyter-Book docs, though it's all pretty simple.

cc @rickecon @ngpsu22 FYI